### PR TITLE
Add backend implementation plan

### DIFF
--- a/backend-plan.md
+++ b/backend-plan.md
@@ -1,0 +1,56 @@
+# Backend Implementation Plan
+
+This document outlines steps to migrate the scheduling system from the current front-end mock implementation to a real back-end service.
+
+## Key Features from Patients Module
+
+Based on lines 6-16 of `PATIENTS_MODULE.md` the Patients module requires:
+
+- **Master Patient Registry**
+- **Advanced Search Engine**
+- **Smart Filtering System**
+- **Quick Statistics Dashboard**
+- **Complete Patient Profiles** and related features
+
+These features imply a full database with sophisticated query and analytics capabilities.
+
+## Next Steps from `project-status.md`
+
+The **Next Steps** section identifies the following priorities:
+
+1. Patient database implementation
+2. Schedule integration
+3. Production deployment
+
+## Proposed Backend Roadmap
+
+1. **Select Stack and Database**
+   - Choose a server framework such as **Node.js/Express** or **Python/FastAPI**.
+   - Use a relational database like **PostgreSQL** or a document store such as **MongoDB** for patient search and analytics.
+
+2. **Design Data Models**
+   - Base the schema on the detailed patient record in `PATIENTS_MODULE.md`. Include personal information, contact details, health plan data, confirmation history, analytics fields and tags.
+   - Create models for schedules, cars/drivers and confirmation records to support schedule integration.
+
+3. **Implement API Endpoints**
+   - `/patients` &mdash; CRUD operations plus advanced search/filter support
+   - `/appointments` or `/schedule` &mdash; manage schedule entries
+   - `/upload` &mdash; receive spreadsheet files and process them (migrating the logic from `fileProcessor.js`)
+   - `/drivers` or `/cars` &mdash; manage driver/car assignments
+   - Authentication endpoints as needed
+
+4. **Move File Processing to the Server**
+   - Reuse the existing spreadsheet parsing logic in a server-side service for centralized validation and data import.
+
+5. **Support Operational Features**
+   - Add endpoints for confirmation tracking, SMS/WhatsApp communication and analytics as described in the Patients module specification.
+
+6. **Integrate With React Front-End**
+   - Replace mock data with API calls using `fetch` or `axios`.
+   - Maintain the current component structure while sourcing data from the new endpoints.
+
+7. **Deployment and Testing**
+   - Create automated tests for API endpoints.
+   - Plan for staging and production deployment once key integrations are complete.
+
+This plan provides a path to evolve the existing prototype into a full system with a real database and server-side features.


### PR DESCRIPTION
## Summary
- add `backend-plan.md` with instructions for implementing the backend

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684056831fd4832399ff9c98c6aab162